### PR TITLE
chore: Update Dependabot schedule intervals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: uv
     directory: "/"
     schedule:
-      interval: weekly
+      interval: monthly
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -28,7 +28,7 @@ updates:
   - package-ecosystem: pip
     directory: "/.github/workflows"
     schedule:
-      interval: monthly
+      interval: quarterly
     cooldown:
       default-days: 7
       semver-major-days: 14
@@ -43,7 +43,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: monthly
+      interval: quarterly
     cooldown:
       default-days: 7
     commit-message:


### PR DESCRIPTION
Changed the update schedule for uv, pip, and GitHub Actions from monthly to quarterly.